### PR TITLE
Handle case where critic_config == '' or undef properly

### DIFF
--- a/lib/Dist/Zilla/Plugin/CriticTests.pm
+++ b/lib/Dist/Zilla/Plugin/CriticTests.pm
@@ -20,10 +20,9 @@ with qw(
 
 has critic_config => (
     is      => 'ro',
-    isa     => 'Str',
+    isa     => 'Maybe[Str]',
     default => 'perlcritic.rc',
 );
-
 
 sub gather_files {
     my ($self) = @_;
@@ -32,6 +31,7 @@ sub gather_files {
     return unless $data and %$data;
 
     my $stash = get_all_attribute_values( $self->meta, $self);
+    $stash->{critic_config} ||= 'perlcritic.rc';
 
     # NB: This code is a bit generalised really, and could be forked into its
     # own plugin.

--- a/t/manifest.t
+++ b/t/manifest.t
@@ -1,0 +1,139 @@
+use strict;
+use warnings;
+use autodie;
+use Test::More 0.94;# tests => 2;
+use Test::DZil;
+use Moose::Autobox;
+
+my $rc_content = do { local $/; <DATA>};
+my $test_name = 'xt/author/critic.t';
+
+subtest 'default' => sub {
+    plan tests => 3;
+
+    my $critic_config = 'perlcritic.rc';
+    my $tzil = Builder->from_config(
+        { dist_root => 'corpus/dist/DZT' },
+        {
+            add_files => {
+                'source/dist.ini' => simple_ini(
+                    ('GatherDir', 'CriticTests')
+                ),
+                "source/$critic_config" => $rc_content,
+            },
+        },
+    );
+
+    $tzil->build;
+
+    my $has_test = grep(
+        $_->name eq $test_name,
+        $tzil->files->flatten
+    );
+    ok($has_test, 'Perl::Critic test exists')
+        or diag explain $tzil->files->flatten;
+
+    my $critic_test = $tzil->slurp_file("build/$test_name");
+    like($critic_test, qr{Test::Perl::Critic}, 'We have a Perl::Critic test');
+    like($critic_test, qr{$critic_config}, 'Right config file used');
+};
+
+subtest '.perlcriticrc' => sub {
+    plan tests => 3;
+
+    my $critic_config = '.perlcriticrc';
+    my $tzil = Builder->from_config(
+        { dist_root => 'corpus/dist/DZT' },
+        {
+            add_files => {
+                'source/dist.ini' => simple_ini(
+                    ('GatherDir', ['CriticTests' => { critic_config => $critic_config}])
+                ),
+                "source/$critic_config" => $rc_content,
+            },
+        },
+    );
+
+    $tzil->build;
+
+    my $has_test = grep(
+        $_->name eq $test_name,
+        $tzil->files->flatten
+    );
+    ok($has_test, 'Perl::Critic test exists')
+        or diag explain $tzil->files->flatten;
+
+    my $critic_test = $tzil->slurp_file("build/$test_name");
+    like($critic_test, qr{Test::Perl::Critic}, 'We have a Perl::Critic test');
+    like($critic_test, qr{$critic_config}, 'Right config file used')
+};
+
+subtest 'empty' => sub {
+    plan tests => 3;
+
+    my $critic_config = 'perlcritic.rc';
+    my $tzil = Builder->from_config(
+        { dist_root => 'corpus/dist/DZT' },
+        {
+            add_files => {
+                'source/dist.ini' => simple_ini(
+                    ('GatherDir', ['CriticTests', { critic_config => '' }])
+                ),
+                "source/$critic_config" => $rc_content,
+            },
+        },
+    );
+
+    $tzil->build;
+
+    my $has_test = grep(
+        $_->name eq $test_name,
+        $tzil->files->flatten
+    );
+    ok($has_test, 'Perl::Critic test exists')
+        or diag explain $tzil->files->flatten;
+
+    my $critic_test = $tzil->slurp_file("build/$test_name");
+    like($critic_test, qr{Test::Perl::Critic}, 'We have a Perl::Critic test');
+    like($critic_test, qr{$critic_config}, 'Right config file used')
+};
+
+subtest 'undef' => sub {
+    plan tests => 3;
+
+    my $critic_config = 'perlcritic.rc';
+    my $tzil = Builder->from_config(
+        { dist_root => 'corpus/dist/DZT' },
+        {
+            add_files => {
+                'source/dist.ini' => simple_ini(
+                    ('GatherDir', ['CriticTests', { critic_config => undef }])
+                ),
+                "source/$critic_config" => $rc_content,
+            },
+        },
+    );
+
+    $tzil->build;
+
+    my $has_test = grep(
+        $_->name eq $test_name,
+        $tzil->files->flatten
+    );
+    ok($has_test, 'Perl::Critic test exists')
+        or diag explain $tzil->files->flatten;
+
+    my $critic_test = $tzil->slurp_file("build/$test_name");
+    like($critic_test, qr{Test::Perl::Critic}, 'We have a Perl::Critic test');
+    like($critic_test, qr{$critic_config}, 'Right config file used')
+};
+
+done_testing;
+
+END { # Remove (empty) dir created by building the dists
+    require File::Path;
+    File::Path::rmtree('tmp');
+}
+
+__DATA__
+severity = 3


### PR DESCRIPTION
This also adds a simple manifest test to make sure the test
file is included OK, and checks that parts of the test file
we care about getting right.

Fixes [rt.cpan.org #68451] dies when critic_config is undef
