### PR TITLE
Inject a recommends prereq for Test::Perl::Critic

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,3 +18,6 @@ x_MailingList = http://www.listbox.com/subscribe/?list_id=139292
 [Bootstrap::lib]
 [@JQUELIN]
 major_version = 2
+
+[Prereq / RuntimeRecommends]
+Test::Perl::Critic = 0


### PR DESCRIPTION
(github is supposed to merge this commit with the previous one; sorry if it didn't do so)
