### PR TITLE
Remove need of MooseX::Autobox for tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist::Zilla::Plugin::Test::Perl::Critic
 
 {{$NEXT}}
+ - Remove need of MooseX::Autobox for tests. (Kent Fredric; GH #6)
 
 2.112410  2011-08-29 14:00:34 Europe/Paris
  - Renamed distribution to .*-Test-Perl-Critic, previous name

--- a/README.mkdn
+++ b/README.mkdn
@@ -1,0 +1,64 @@
+# NAME
+
+Dist::Zilla::Plugin::Test::Perl::Critic - tests to check your code against best practices
+
+# VERSION
+
+version 2.112411
+
+# SYNOPSIS
+
+In your dist.ini:
+
+    [Test::Perl::Critic]
+    critic_config = perlcritic.rc   ; relative to project root
+
+# DESCRIPTION
+
+This is an extension of [Dist::Zilla::Plugin::InlineFiles](https://metacpan.org/pod/Dist::Zilla::Plugin::InlineFiles), providing
+the following files:
+
+- t/author/critic.t - a standard test to check your code against best practices
+
+This plugin accept the `critic_config` option, to specify your own config
+file for [Perl::Critic](https://metacpan.org/pod/Perl::Critic). It defaults to `perlcritic.rc`, relative to the
+project root.
+
+# SEE ALSO
+
+You can look for information on this module at:
+
+- Search CPAN
+
+    [http://search.cpan.org/dist/Dist-Zilla-Plugin-Test-Perl-Critic](http://search.cpan.org/dist/Dist-Zilla-Plugin-Test-Perl-Critic)
+
+- See open / report bugs
+
+    [http://rt.cpan.org/NoAuth/Bugs.html?Dist=Dist-Zilla-Plugin-Test-Perl-Critic](http://rt.cpan.org/NoAuth/Bugs.html?Dist=Dist-Zilla-Plugin-Test-Perl-Critic)
+
+- Mailing-list (same as [Dist::Zilla](https://metacpan.org/pod/Dist::Zilla))
+
+    [http://www.listbox.com/subscribe/?list\_id=139292](http://www.listbox.com/subscribe/?list_id=139292)
+
+- Git repository
+
+    [http://github.com/jquelin/dist-zilla-plugin-test-perl-critic](http://github.com/jquelin/dist-zilla-plugin-test-perl-critic)
+
+- AnnoCPAN: Annotated CPAN documentation
+
+    [http://annocpan.org/dist/Dist-Zilla-Plugin-Test-Perl-Critic](http://annocpan.org/dist/Dist-Zilla-Plugin-Test-Perl-Critic)
+
+- CPAN Ratings
+
+    [http://cpanratings.perl.org/d/Dist-Zilla-Plugin-Test-Perl-Critic](http://cpanratings.perl.org/d/Dist-Zilla-Plugin-Test-Perl-Critic)
+
+# AUTHOR
+
+Jerome Quelin
+
+# COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2009 by Jerome Quelin.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.

--- a/dist.ini
+++ b/dist.ini
@@ -16,5 +16,5 @@ x_MailingList = http://www.listbox.com/subscribe/?list_id=139292
 ;[Test::Perl::Critic]
 
 [Bootstrap::lib]
-[@JQUELIN]
+[@Author::JQUELIN]
 major_version = 2

--- a/t/manifest.t
+++ b/t/manifest.t
@@ -3,7 +3,6 @@ use warnings;
 use autodie;
 use Test::More 0.94;# tests => 2;
 use Test::DZil;
-use Moose::Autobox;
 
 my $rc_content = do { local $/; <DATA>};
 my $test_name = 'xt/author/critic.t';
@@ -28,10 +27,10 @@ subtest 'default' => sub {
 
     my $has_test = grep(
         $_->name eq $test_name,
-        $tzil->files->flatten
+        @{ $tzil->files }
     );
     ok($has_test, 'Perl::Critic test exists')
-        or diag explain $tzil->files->flatten;
+        or diag explain @{ $tzil->files };
 
     my $critic_test = $tzil->slurp_file("build/$test_name");
     like($critic_test, qr{Test::Perl::Critic}, 'We have a Perl::Critic test');
@@ -58,10 +57,10 @@ subtest '.perlcriticrc' => sub {
 
     my $has_test = grep(
         $_->name eq $test_name,
-        $tzil->files->flatten
+        @{ $tzil->files }
     );
     ok($has_test, 'Perl::Critic test exists')
-        or diag explain $tzil->files->flatten;
+        or diag explain @{ $tzil->files };
 
     my $critic_test = $tzil->slurp_file("build/$test_name");
     like($critic_test, qr{Test::Perl::Critic}, 'We have a Perl::Critic test');
@@ -88,10 +87,10 @@ subtest 'empty' => sub {
 
     my $has_test = grep(
         $_->name eq $test_name,
-        $tzil->files->flatten
+        @{ $tzil->files }
     );
     ok($has_test, 'Perl::Critic test exists')
-        or diag explain $tzil->files->flatten;
+        or diag explain @{ $tzil->files };
 
     my $critic_test = $tzil->slurp_file("build/$test_name");
     like($critic_test, qr{Test::Perl::Critic}, 'We have a Perl::Critic test');
@@ -118,10 +117,10 @@ subtest 'undef' => sub {
 
     my $has_test = grep(
         $_->name eq $test_name,
-        $tzil->files->flatten
+        @{ $tzil->files }
     );
     ok($has_test, 'Perl::Critic test exists')
-        or diag explain $tzil->files->flatten;
+        or diag explain @{ $tzil->files };
 
     my $critic_test = $tzil->slurp_file("build/$test_name");
     like($critic_test, qr{Test::Perl::Critic}, 'We have a Perl::Critic test');


### PR DESCRIPTION
Same fix and rationale as https://github.com/doherty/Dist-Zilla-Plugin-Test-CPAN-Changes/pull/5

( But `@Author::JQUELIN`installs so I did a proper `dzil test` :D  )
