### PR TITLE
Inject develop/requires dependencies

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,16 +8,13 @@ copyright_year   = 2009
 [MetaResources]
 x_MailingList = http://www.listbox.com/subscribe/?list_id=139292
 
-;This stuff is handy if things go seriously wrong.
-;[@Filter]
-;-bundle = @JQUELIN
-;-remove = Test::Perl::Critic
-;[CriticTests]
-;[Test::Perl::Critic]
-
 [Bootstrap::lib]
 [@Author::JQUELIN]
 major_version = 2
+
+; Test ourself
+; (this is not in @Author::JQUELIN)
+[Test::Perl::Critic]
 
 [Prereqs]
 Test::Perl::Critic = 0

--- a/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
@@ -15,6 +15,7 @@ use Data::Section 0.004 -setup;
 with qw(
     Dist::Zilla::Role::FileGatherer
     Dist::Zilla::Role::TextTemplate
+    Dist::Zilla::Role::PrereqSource
 );
 
 has critic_config => (
@@ -43,12 +44,27 @@ sub gather_files {
     }
 }
 
+sub register_prereqs {
+    my $self = shift;
+
+    $self->zilla->register_prereqs(
+        {
+            type  => 'requires',
+            phase => 'develop',
+        },
+        'Test::More'         => 0,
+        'Test::Perl::Critic' => 0,
+
+        # TODO also extract list of policies used in file $self->critic_config
+    );
+}
+
 no Moose;
 __PACKAGE__->meta->make_immutable;
 1;
 =pod
 
-=for Pod::Coverage gather_files
+=for Pod::Coverage gather_files register_prereqs
 
 =head1 SYNOPSIS
 

--- a/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
@@ -52,7 +52,6 @@ sub register_prereqs {
             type  => 'requires',
             phase => 'develop',
         },
-        'Test::More'         => 0,
         'Test::Perl::Critic' => 0,
 
         # TODO also extract list of policies used in file $self->critic_config
@@ -132,10 +131,5 @@ ___[ xt/author/critic.t ]___
 use strict;
 use warnings;
 
-use Test::More;
-use English qw(-no_match_vars);
-
-eval "use Test::Perl::Critic";
-plan skip_all => 'Test::Perl::Critic required to criticise code' if $@;
-Test::Perl::Critic->import( -profile => "{{ $critic_config }}" ) if -e "{{ $critic_config }}";
+use Test::Perl::Critic (-profile => "{{ $critic_config }}") x!! -e "{{ $critic_config }}";
 all_critic_ok();


### PR DESCRIPTION
- Inject Test::Perl::Critic as `develop`/`requires` dependency so it is listed in `dzil listdeps --develop`
- Run the test unconditionally: a missing module is not a valid reason to skip an author test
